### PR TITLE
Add component sorting customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## unreleased
+- Support configuring component sorting list
 
 ## [0.2.3] - 2025-04-23
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The playground is powered by the [openapi-format](https://www.npmjs.com/package/
 
 - Format OpenAPI documents to enhance readability
 - Sort OpenAPI document sections for consistency
+- Customize components sorting order
 - Filter OpenAPI document content
 - Apply OpenAPI Overlay actions to OpenAPI document content
 - Format the casing of OpenAPI elements

--- a/src/components/ButtonUpload.tsx
+++ b/src/components/ButtonUpload.tsx
@@ -3,7 +3,7 @@ import React, {useState} from 'react';
 import {parseString, stringify} from "openapi-format";
 
 interface FileUploadProps {
-  context: 'playground' | 'overlay' | 'sort';
+  context: 'playground' | 'overlay' | 'sort' | 'sortComponents';
   onFileLoad: (content: string | null, context: string) => void;
 }
 

--- a/src/components/ButtonUrlModal.tsx
+++ b/src/components/ButtonUrlModal.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import SimpleModal from './SimpleModal';
 
 interface UrlUploadProps {
-  context: 'playground' | 'overlay' | 'sort';
+  context: 'playground' | 'overlay' | 'sort' | 'sortComponents';
   typeTxt?: string;
   onUrlLoad: (content: string | null, context: string) => void;
 }

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -9,6 +9,7 @@ import ButtonDownload from '@/components/ButtonDownload';
 import ButtonShare from "@/components/ButtonShare";
 
 import defaultSort from '../defaults/defaultSort.json'
+import defaultSortComponents from '../defaults/defaultSortComponents.json'
 
 import {
   analyzeOpenApi,
@@ -28,6 +29,7 @@ import RawConfigModal from "@/components/RawConfigModal";
 import GenerateFormModal from "@/components/GenerateFormModal";
 import CasingFormModal from "@/components/CasingFormModal";
 import SortOptionsModal from "@/components/SortOptionsModal";
+import SortComponentsModal from "@/components/SortComponentsModal";
 import ButtonUrlModal from "@/components/ButtonUrlModal";
 import OverlayModal from "@/components/OverlayModal";
 
@@ -65,6 +67,7 @@ export interface openapiFormatConfig {
   keepComments?: boolean;
   filterSet?: string;
   sortSet?: string;
+  sortComponentsSet?: string;
   overlaySet?: string;
   generateSet?: string;
   casingSet?: string;
@@ -85,6 +88,9 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
   const [defaultSortSet, setDefaultSortSet] = useState<string>('');
   const [customSortSet, setCustomSortSet] = useState<string>(defaultSortSet);
   const [sortSet, setSortSet] = useState<string>(defaultSortSet);
+  const [defaultSortComponentsSet, setDefaultSortComponentsSet] = useState<string>('');
+  const [customSortComponentsSet, setCustomSortComponentsSet] = useState<string>(defaultSortComponentsSet);
+  const [sortComponentsSet, setSortComponentsSet] = useState<string>(defaultSortComponentsSet);
   const [overlaySet, setOverlaySet] = useState<string>('');
   const [isFilterOptionsCollapsed, setFilterOptionsCollapsed] = useState<boolean>(false);
   const [outputLanguage, setOutputLanguage] = useState<'json' | 'yaml'>('yaml');
@@ -93,6 +99,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
   const [isGenerateModalOpen, setGenerateModalOpen] = useState(false);
   const [isCasingModalOpen, setCasingModalOpen] = useState(false);
   const [isSortModalOpen, setSortModalOpen] = useState(false);
+  const [isSortComponentsModalOpen, setSortComponentsModalOpen] = useState(false);
   const [isFormModalOpen, setFormModalOpen] = useState(false);
   const [isOverlayModalOpen, setOverlayModalOpen] = useState(false);
   const [isInstructionsModalOpen, setInstructionsModalOpen] = useState(false);
@@ -120,6 +127,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
   const dInput = useDebounce(input, 1000);
   const dFilterSet = useDebounce(filterSet, 1000);
   const dSortSet = useDebounce(sortSet, 1000);
+  const dSortComponentsSet = useDebounce(sortComponentsSet, 1000);
   const dOverlaySet = useDebounce(overlaySet, 1000);
   const dGenerateSet = useDebounce(generateSet, 1000);
   const dCasingSet = useDebounce(casingSet, 1000);
@@ -129,6 +137,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
     keepComments,
     filterSet,
     sortSet,
+    sortComponentsSet,
     casingSet,
     overlaySet,
     generateSet,
@@ -161,6 +170,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
       keepComments: keepComments,
       filterSet: dFilterSet,
       sortSet: dSortSet,
+      sortComponentsSet: dSortComponentsSet,
       ...(dOverlaySet && toggleOverlay && {overlaySet: dOverlaySet}),
       ...(dGenerateSet && toggleGenerate && {generateSet: dGenerateSet}),
       ...(dCasingSet && toggleCasing && {casingSet: dCasingSet}),
@@ -213,7 +223,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
       setOutput('');
     }
     setLoading(false);
-  }, [dInput, sort, keepComments, dFilterSet, dSortSet, dGenerateSet, dCasingSet, dOverlaySet, outputLanguage, pathSort, toggleGenerate, toggleCasing, toggleOverlay, setOutput, defaultFieldSorting]);
+  }, [dInput, sort, keepComments, dFilterSet, dSortSet, dSortComponentsSet, dGenerateSet, dCasingSet, dOverlaySet, outputLanguage, pathSort, toggleGenerate, toggleCasing, toggleOverlay, setOutput, defaultFieldSorting]);
 
   // Decode Share URL
   useEffect(() => {
@@ -233,8 +243,10 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
           setGenerateSet(result.config.generateSet ?? '');
           setCasingSet(result.config.casingSet ?? '');
           setSortSet(result.config.sortSet ?? '');
+          setSortComponentsSet(result.config.sortComponentsSet ?? '');
           setOverlaySet(result.config.overlaySet ?? '');
           setCustomSortSet(result.config.sortSet ?? defaultSortSet);
+          setCustomSortComponentsSet(result.config.sortComponentsSet ?? defaultSortComponentsSet);
 
           setToggleOverlay(result.config.toggleOverlay ?? false);
           setToggleCasing(result.config.toggleCasing ?? false);
@@ -261,6 +273,10 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
       const result = await stringify(defaultSort, {format: outputLanguage});
       setDefaultSortSet(result);
     };
+    const convertSortComponentsSet = async () => {
+      const result = await stringify(defaultSortComponents, {format: outputLanguage});
+      setDefaultSortComponentsSet(result);
+    };
     const convertFilterSet = async () => {
       if (filterSet && filterSet.length > 0) {
 
@@ -278,6 +294,7 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
     };
 
     convertSortSet();
+    convertSortComponentsSet();
     convertFilterSet();
   }, [outputLanguage, dFilterSet]);
 
@@ -323,6 +340,10 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
 
   const openSortModal = () => {
     setSortModalOpen(true);
+  };
+
+  const openSortComponentsModal = () => {
+    setSortComponentsModalOpen(true);
   };
 
   const openFormModal = () => {
@@ -380,6 +401,12 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
     setCustomSortSet(sortOptions);
     setSortSet(sortOptions);
     setSortModalOpen(false);
+  };
+
+  const handleSortComponentsSubmit = async (list: any) => {
+    setCustomSortComponentsSet(list);
+    setSortComponentsSet(list);
+    setSortComponentsModalOpen(false);
   };
 
   const handleOverlaySubmit = async (overlayOptions: any) => {
@@ -502,6 +529,17 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
                   </label>
                   <button
                     onClick={openSortModal}
+                    className="bg-blue-500 text-white text-xs p-1 rounded-full hover:bg-blue-600 focus:outline-none"
+                  >
+                    Configure
+                  </button>
+                </div>
+                <div className="flex items-center mt-2">
+                  <label className="flex items-center font-medium text-gray-700 dark:text-gray-400 mr-2">
+                    Custom components sorting
+                  </label>
+                  <button
+                    onClick={openSortComponentsModal}
                     className="bg-blue-500 text-white text-xs p-1 rounded-full hover:bg-blue-600 focus:outline-none"
                   >
                     Configure
@@ -728,6 +766,15 @@ const Playground: React.FC<PlaygroundProps> = ({input, setInput, output, setOutp
         onSubmit={handleSortSubmit}
         outputLanguage={outputLanguage}
         defaultSort={defaultSortSet}
+      />
+
+      <SortComponentsModal
+        isOpen={isSortComponentsModalOpen}
+        onRequestClose={() => setSortComponentsModalOpen(false)}
+        sortComponentsSet={customSortComponentsSet}
+        onSubmit={handleSortComponentsSubmit}
+        outputLanguage={outputLanguage}
+        defaultSortComponents={defaultSortComponentsSet}
       />
 
       <OverlayModal

--- a/src/components/SortComponentsModal.tsx
+++ b/src/components/SortComponentsModal.tsx
@@ -1,0 +1,106 @@
+import React, {useEffect, useState} from "react";
+import SimpleModal from "./SimpleModal"; // Assuming you have a SimpleModal component
+import MonacoEditorWrapper from "./MonacoEditorWrapper";
+import ButtonDownload from "./ButtonDownload";
+import ButtonUrlModal from "@/components/ButtonUrlModal";
+import ButtonUpload from "@/components/ButtonUpload";
+
+interface SortComponentsModalProps {
+  isOpen: boolean;
+  onRequestClose: () => void;
+  onSubmit: (sortingSet: string) => void;
+  sortComponentsSet: string;
+  defaultSortComponents: string; // default sorting list
+  outputLanguage: 'json' | 'yaml';
+}
+
+const SortComponentsModal: React.FC<SortComponentsModalProps> = ({isOpen, onRequestClose, onSubmit, sortComponentsSet, outputLanguage, defaultSortComponents}) => {
+  const [localSortComponentsSet, setLocalSortComponentsSet] = useState(sortComponentsSet);
+
+  useEffect(() => {
+    if (sortComponentsSet) {
+      setLocalSortComponentsSet(sortComponentsSet);
+    }
+  }, [sortComponentsSet]);
+
+  const handleSortLoad = (content: string | null, context: string) => {
+    if (context === 'sortComponents' && content) {
+      setLocalSortComponentsSet(content);
+    }
+  };
+
+  // Handle Reset: Reset localSortComponentsSet to default
+  const handleReset = () => {
+    setLocalSortComponentsSet(defaultSortComponents);
+  };
+
+  const handleSubmit = () => {
+    onSubmit(localSortComponentsSet);  // Submit the updated sorting set
+    onRequestClose();  // Close the modal after submit
+  };
+
+  return (
+    <SimpleModal isOpen={isOpen} onRequestClose={onRequestClose} width="50%" height="60%">
+      <h3 className="text-lg font-semibold mb-4">
+        Custom field sorting
+      </h3>
+
+      <div className="flex items-center justify-between gap-2 mb-4">
+        <div className="flex items-center gap-2">
+          <ButtonUrlModal
+            context="sortComponents"
+            typeTxt="Components Sort"
+            onUrlLoad={(content, context) => {
+              handleSortLoad(content, context);
+            }}
+          />
+          <ButtonUpload
+            context="sortComponents"
+            onFileLoad={handleSortLoad}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <ButtonDownload
+            content={localSortComponentsSet}
+            filename="oaf-sort-components"
+            format={outputLanguage}
+            label="Download list"
+            className="bg-green-500 text-white text-xs p-2 rounded hover:bg-green-700 focus:outline-none"
+          />
+          <button
+            onClick={handleReset}
+            className="bg-yellow-500 text-white text-xs p-2 rounded hover:bg-yellow-600 focus:outline-none"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <MonacoEditorWrapper
+          value={localSortComponentsSet}  // Local state holding sort options
+          onChange={setLocalSortComponentsSet}  // Update the local state when the user edits
+          language={outputLanguage === 'json' ? 'json' : 'yaml'}
+          height="40vh"
+        />
+      </div>
+
+      <div className="flex justify-end space-x-2 mt-4">
+        <button
+          onClick={onRequestClose}
+          className="bg-gray-300 dark:bg-gray-500 p-2 rounded hover:bg-gray-400 focus:outline-none"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          className="bg-blue-500 text-white p-2 rounded hover:bg-blue-600 focus:outline-none"
+        >
+          Apply Sorting
+        </button>
+      </div>
+    </SimpleModal>
+  );
+};
+
+export default SortComponentsModal;

--- a/src/pages/api/format.ts
+++ b/src/pages/api/format.ts
@@ -15,6 +15,7 @@ import {
 
 import defaultFilterJson from '../../defaults/defaultFilter.json'
 import defaultSortJson from '../../defaults/defaultSort.json'
+import defaultSortComponentsJson from '../../defaults/defaultSortComponents.json'
 import {OpenAPIV3} from "openapi-types";
 
 export default async function format(req: NextApiRequest, res: NextApiResponse) {
@@ -24,7 +25,7 @@ export default async function format(req: NextApiRequest, res: NextApiResponse) 
   }
 
   const {openapi, config} = req.body;
-  const {sort, keepComments, filterSet, sortSet, generateSet, casingSet, overlaySet, format} = config || {};
+  const {sort, keepComments, filterSet, sortSet, sortComponentsSet, generateSet, casingSet, overlaySet, format} = config || {};
 
   if (!openapi) {
     res.status(422).json({message: 'Missing openapi'});
@@ -71,7 +72,13 @@ export default async function format(req: NextApiRequest, res: NextApiResponse) 
         sortOpts = await parseString(sortSet) as OpenAPISortSet
       }
       const defaultOpts = defaultSortJson as OpenAPISortSet;
-      const options = {sortSet: Object.assign({}, defaultOpts, sortOpts), sortComponentsSet: []} as OpenAPISortOptions;
+      let compOpts: string[] = [];
+      if (sortComponentsSet) {
+        compOpts = await parseString(sortComponentsSet) as string[];
+      } else {
+        compOpts = defaultSortComponentsJson as string[];
+      }
+      const options = {sortSet: Object.assign({}, defaultOpts, sortOpts), sortComponentsSet: compOpts} as OpenAPISortOptions;
       const sortedRes = await openapiSort(oaObj, options) as OpenAPIResult;
       output.data = sortedRes.data;
       oaObj = output.data as OpenAPIV3.Document || {data: oaObj};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ export const generateShareUrl = async (origin: string, openapi?: string, config?
     const configOps = {} as PlaygroundConfig;
 
     if (config.sortSet !== undefined) configOps.sortSet = await stringify(config.sortSet);
+    if (config.sortComponentsSet !== undefined) configOps.sortComponentsSet = await stringify(config.sortComponentsSet);
     if (config.filterSet !== undefined) configOps.filterSet = await stringify(config.filterSet);
     if (config.generateSet !== undefined) configOps.generateSet = await stringify(config.generateSet);
     if (config.casingSet !== undefined) configOps.casingSet = await stringify(config.casingSet);


### PR DESCRIPTION
## Summary
- allow editing a custom component sorting list
- add SortComponentsModal UI
- pass sortComponentsSet through share URLs and API
- document new option

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840055f62b883219e6f5026ffe6443e